### PR TITLE
Catch UnicodeErrors

### DIFF
--- a/app_builder/command_thread.py
+++ b/app_builder/command_thread.py
@@ -61,6 +61,9 @@ class CommandThread(threading.Thread):
                 self._on_finished(False)
             else:
                 raise e
+        except UnicodeError as e:
+            main_thread(log_error, "Unable to execute command, check for non-ascii symbols in the path to your project.")
+            self._on_finished(False)
 
     def success(self):
         if self.is_alive():

--- a/app_builder/project.py
+++ b/app_builder/project.py
@@ -1,5 +1,6 @@
 import os
 import json
+import codecs
 
 class Project(object):
     PROJECT_FILE_NAME = ".abproject"
@@ -23,6 +24,11 @@ class Project(object):
 
     @staticmethod
     def get_project_name(path):
-        json_data = open(os.path.join(path, Project.PROJECT_FILE_NAME))
-        project_data = json.load(json_data)
-        return project_data["DisplayName"]
+        try:
+            json_data = codecs.open(os.path.join(path, Project.PROJECT_FILE_NAME), "r", "utf-8")
+            project_data = json.load(json_data)
+            return project_data["DisplayName"]
+        except UnicodeError as e:
+            print("Unable to parse project file: " + Project.PROJECT_FILE_NAME)
+            # Do not raise error here, just return empty string. The calling method will start the first project in the dir, so getting DisplayName is optional
+            return ""


### PR DESCRIPTION
Add catch for UnicodeError when executing command. Change .abproject file to be opened with "utf-8" encoding (using codecs), so even if DisplayName (or any other property) has value with non-ASCII symbols, it should be parsed correctly.
The only issue that remains is on Windows with Sublime 2 when path to project has non-ASCII symbols (for example cyrillic) - Python 2.7 cannot handle this case, so we are just showing error message.

Fixes http://teampulse.telerik.com/view#item/278007
