### PR TITLE
Depend on major and minor version of CLI

### DIFF
--- a/app_builder/bootstrapper.py
+++ b/app_builder/bootstrapper.py
@@ -3,7 +3,8 @@ import os
 import json
 
 from .notifier import log_info, log_fail
-from .helpers import parse_version_string
+from .semver import *
+from .helpers import get_major_minor_version_from_string
 
 _has_compatible_working_appbuilder_cli = None
 _config = None
@@ -21,21 +22,31 @@ def _load_config():
         "linux_appbuilder_path": settings.get("linux_appbuilder_path") or "",
         "win_node_name": "node",
         "win_appbuilder_name": "appbuilder",
-        "required_appbuilder_cli_version": "2.7.3"
+        "min_required_appbuilder_cli_version": "2.8.0", #inclusive
+        "max_allowed_appbuilder_cli_version": "2.9.0"  #exclusive
     }
 
 def _verify_appbuilder_cli_version(installed_appbuilder_cli_version):
     global _has_compatible_working_appbuilder_cli
-    required_appbuilder_cli_version = parse_version_string(get_config("required_appbuilder_cli_version"))
-    if installed_appbuilder_cli_version == required_appbuilder_cli_version:
+    min_required_appbuilder_cli_version = get_config("min_required_appbuilder_cli_version")
+    max_allowed_appbuilder_cli_version = get_config("max_allowed_appbuilder_cli_version")
+    validMinVersion = match(installed_appbuilder_cli_version, ">="+min_required_appbuilder_cli_version)
+    validMaxVersion = match(installed_appbuilder_cli_version, "<"+max_allowed_appbuilder_cli_version)
+    if validMinVersion and validMaxVersion:
         _has_compatible_working_appbuilder_cli = True
         log_info("Telerik AppBuilder has been initialized successfully")
     else:
         _has_compatible_working_appbuilder_cli = False
-        log_fail("Cannot load the Telerik AppBuilder package because the required version of Telerik AppBuilder command-line interface is {required_version}.\n".
-            format(required_version=".".join(required_appbuilder_cli_version)) +
-            "The Telerik AppBuilder command-line interface version that has been found is {installed_version}".
-            format(installed_version=".".join(installed_appbuilder_cli_version)))
+        if not validMinVersion:
+            log_fail("You have updated your Telerik AppBuilder package to {required_min_version}.\n".
+                format(required_min_version=min_required_appbuilder_cli_version) +
+                "To be able to load it, you need to update your Telerik AppBuilder CLI to {installed_version}.x.".
+                format(installed_version=".".join(get_major_minor_version_from_string(min_required_appbuilder_cli_version))))
+        if not validMaxVersion:
+            log_fail("You have updated your Telerik AppBuilder CLI to {cli_version}.\n".
+                format(cli_version=installed_appbuilder_cli_version) +
+                "To be able to load the Telerik AppBuilder package, you need to update the package to at least {required_min_version}.0.". 
+                format(required_min_version=".".join(get_major_minor_version_from_string(installed_appbuilder_cli_version))))
 
 def get_config(name):
     global _config

--- a/app_builder/helpers.py
+++ b/app_builder/helpers.py
@@ -1,4 +1,4 @@
 import re
 
-def parse_version_string(version_string):
-    return re.split("[\.-]", version_string.strip())[:3]
+def get_major_minor_version_from_string(version_string):
+    return re.split("[\.-]", version_string.strip())[:2]

--- a/app_builder/semver.py
+++ b/app_builder/semver.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+
+import re
+
+_REGEX = re.compile('^(?P<major>(?:0|[1-9][0-9]*))'
+                    '\.(?P<minor>(?:0|[1-9][0-9]*))'
+                    '\.(?P<patch>(?:0|[1-9][0-9]*))'
+                    '(\-(?P<prerelease>[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?'
+                    '(\+(?P<build>[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?$')
+
+if 'cmp' not in __builtins__:
+    cmp = lambda a, b: (a > b) - (a < b)
+
+
+def parse(version):
+    """
+    Parse version to major, minor, patch, pre-release, build parts.
+    """
+    match = _REGEX.match(version)
+    if match is None:
+        raise ValueError('%s is not valid SemVer string' % version)
+
+    verinfo = match.groupdict()
+
+    verinfo['major'] = int(verinfo['major'])
+    verinfo['minor'] = int(verinfo['minor'])
+    verinfo['patch'] = int(verinfo['patch'])
+
+    return verinfo
+
+
+def compare(ver1, ver2):
+    def nat_cmp(a, b):
+        a, b = a or '', b or ''
+        convert = lambda text: text.isdigit() and int(text) or text.lower()
+        alphanum_key = lambda key: [convert(c) for c in re.split('([0-9]+)', key)]
+        return cmp(alphanum_key(a), alphanum_key(b))
+
+    def compare_by_keys(d1, d2):
+        for key in ['major', 'minor', 'patch']:
+            v = cmp(d1.get(key), d2.get(key))
+            if v:
+                return v
+        rc1, rc2 = d1.get('prerelease'), d2.get('prerelease')
+        rccmp = nat_cmp(rc1, rc2)
+        if not (rc1 or rc2):
+            return rccmp
+        if not rc1:
+            return 1
+        elif not rc2:
+            return -1
+        return rccmp or 0
+
+    v1, v2 = parse(ver1), parse(ver2)
+
+    return compare_by_keys(v1, v2)
+
+
+def match(version, match_expr):
+    prefix = match_expr[:2]
+    if prefix in ('>=', '<=', '=='):
+        match_version = match_expr[2:]
+    elif prefix and prefix[0] in ('>', '<', '='):
+        prefix = prefix[0]
+        match_version = match_expr[1:]
+    else:
+        raise ValueError("match_expr parameter should be in format <op><ver>, "
+                         "where <op> is one of ['<', '>', '==', '<=', '>=']. "
+                         "You provided: %r" % match_expr)
+
+    possibilities_dict = {
+        '>': (1,),
+        '<': (-1,),
+        '==': (0,),
+        '>=': (0, 1),
+        '<=': (-1, 0)
+    }
+
+    possibilities = possibilities_dict[prefix]
+    cmp_res = compare(version, match_version)
+
+    return cmp_res in possibilities

--- a/telerik_appbuilder.py
+++ b/telerik_appbuilder.py
@@ -12,7 +12,6 @@ try:
     from .app_builder import command_executor
     from .app_builder import bootstrapper
     from .app_builder.notifier import log_fail, log_error
-    from .app_builder.helpers import parse_version_string
     from .app_builder.feature_usage_tracking import ensure_feature_usage_tracking_is_set
 
 except (ValueError):
@@ -21,7 +20,6 @@ except (ValueError):
     from app_builder import command_executor
     from app_builder import bootstrapper
     from app_builder.notifier import log_fail, log_error
-    from app_builder.helpers import parse_version_string
     from app_builder.feature_usage_tracking import ensure_feature_usage_tracking_is_set
 
 def plugin_loaded():
@@ -29,7 +27,9 @@ def plugin_loaded():
     def on_data(data):
         global installed_appbuilder_cli_version
         if data:
-            installed_appbuilder_cli_version = parse_version_string(data)
+            if data[-1] == "\n":
+                data = data[:-1]
+            installed_appbuilder_cli_version = data
 
     def on_done(succeeded):
         global installed_appbuilder_cli_version


### PR DESCRIPTION
Sublime package should depend only on <major>.<minor> versions of appbuilder-cli, so if CLI is 2.8.0, 2.8.1, 2.8.2, etc. sublime package should work fine (depending on 2.8.*). Add compare_versions method that checks if in the required version we have star - * symbol and ignoring it in the comparison. Updated required_appbuilder_cli_version to 2.8.*

http://teampulse.telerik.com/view#item/284276