### PR TITLE
Fix version comparison

### DIFF
--- a/app_builder/bootstrapper.py
+++ b/app_builder/bootstrapper.py
@@ -4,7 +4,7 @@ import json
 
 from .notifier import log_info, log_fail
 from .semver import *
-from .helpers import get_major_minor_version_from_string
+from .helpers import *
 
 _has_compatible_working_appbuilder_cli = None
 _config = None
@@ -30,8 +30,9 @@ def _verify_appbuilder_cli_version(installed_appbuilder_cli_version):
     global _has_compatible_working_appbuilder_cli
     min_required_appbuilder_cli_version = get_config("min_required_appbuilder_cli_version")
     max_allowed_appbuilder_cli_version = get_config("max_allowed_appbuilder_cli_version")
-    validMinVersion = match(installed_appbuilder_cli_version, ">="+min_required_appbuilder_cli_version)
-    validMaxVersion = match(installed_appbuilder_cli_version, "<"+max_allowed_appbuilder_cli_version)
+    cli_version = get_correct_semversion(installed_appbuilder_cli_version)
+    validMinVersion = match(cli_version, ">="+min_required_appbuilder_cli_version)
+    validMaxVersion = match(cli_version, "<"+max_allowed_appbuilder_cli_version)
     if validMinVersion and validMaxVersion:
         _has_compatible_working_appbuilder_cli = True
         log_info("Telerik AppBuilder has been initialized successfully")

--- a/app_builder/helpers.py
+++ b/app_builder/helpers.py
@@ -2,3 +2,6 @@ import re
 
 def get_major_minor_version_from_string(version_string):
     return re.split("[\.-]", version_string.strip())[:2]
+
+def get_correct_semversion(version_string):
+    return ".".join(re.split("[\.-]", version_string.strip())[:3])


### PR DESCRIPTION
CLI versions are in the following format: 2.8.0-270. Semver library is unable to compare versions with -, so remove this part from the comparison.

Fixes http://teampulse.telerik.com/view#item/285174