### PR TITLE
Set version to 2.9.0

### DIFF
--- a/app_builder/bootstrapper.py
+++ b/app_builder/bootstrapper.py
@@ -22,8 +22,8 @@ def _load_config():
         "linux_appbuilder_path": settings.get("linux_appbuilder_path") or "",
         "win_node_name": "node",
         "win_appbuilder_name": "appbuilder",
-        "min_required_appbuilder_cli_version": "2.8.0", #inclusive
-        "max_allowed_appbuilder_cli_version": "2.9.0"  #exclusive
+        "min_required_appbuilder_cli_version": "2.9.0", #inclusive
+        "max_allowed_appbuilder_cli_version": "2.10.0"  #exclusive
     }
 
 def _verify_appbuilder_cli_version(installed_appbuilder_cli_version):


### PR DESCRIPTION
Set min_required_appbuilder_cli_version to 2.9.0 and max_required_cli_version to 2.10.0. This way all customers using Sublime, will have to install the new version after we release appbuilder CLI 2.9.0