### PR TITLE
Refactor the build process

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,11 +1,7 @@
 module.exports = function(grunt) {
     grunt.initConfig({
-		copyPackageTo: "\\\\telerik.com\\Resources\\BlackDragon\\Builds\\appbuilder-sublime-package",
-		
-        movePackageTo: process.env["JOB_NAME"] ? "\\\\telerik.com\\Resources\\BlackDragon\\Builds\\appbuilder-sublime-package" : "build",
-        jobName: process.env["JOB_NAME"] || "local",
-        buildNumber: process.env["BUILD_NUMBER"] || "non-ci",
-        destinationFolder: process.env["JOB_NAME"] ? "<%= movePackageTo %>\\<%= jobName %>\\<%= grunt.template.today('yyyy-mm-dd') %> #<%= buildNumber %>" : "<%= movePackageTo %>",
+
+        destinationFolder: "build_output",
 
         compress: {
             main: {
@@ -15,17 +11,9 @@ module.exports = function(grunt) {
                 files: [
                     { src: ["**/*.{py,pyd,so}", "*.{sublime-keymap,sublime-menu,sublime-settings}", "LICENSE"] }
                 ]
-            },
-			second: {
-                options: {
-                    archive: "<%= copyPackageTo %>\\<%= jobName %>\\Telerik AppBuilder.zip"
-                },
-                files: [
-                    { src: ["**/*.{py,pyd,so}", "*.{sublime-keymap,sublime-menu,sublime-settings}", "LICENSE"] }
-                ]
             }
         },
-		
+
         clean: {
             src: ["**/*.pyc"]
         }
@@ -33,5 +21,5 @@ module.exports = function(grunt) {
 
     grunt.loadNpmTasks("grunt-contrib-compress");
     grunt.loadNpmTasks("grunt-contrib-clean");
-	grunt.registerTask("default", ["compress:main","compress:second"]);
+    grunt.registerTask("default", "compress:main");
 }


### PR DESCRIPTION
The repo build should produce only a package.
The build jenkins job should decide the destination of the package.
This way we will not have to update the repo each time we change the deploy location.