### PR TITLE
Comma should to be added.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ If Sublime Text cannot load the package properly, verify that the path variables
 
     ```
     {
-        "node_osx_path": "The path retrieved in Step 1"
+        "node_osx_path": "The path retrieved in Step 1",
         "appbuilder_osx_path": "The path retrieved in Step 2"
     }
     ```
@@ -108,7 +108,7 @@ If Sublime Text cannot load the package properly, verify that the path variables
 
     ```
     {
-        "linux_node_path": "The path retrieved in Step 1"
+        "linux_node_path": "The path retrieved in Step 1",
         "linux_appbuilder_path": "The path retrieved in Step 2"
     }
     ```


### PR DESCRIPTION
If you comma doesn't exist, we will have: 
> Error trying to parse settings: Unexpected character, expected a comma or closing bracket in

My system working with follow settings:  

```
{
    "node_osx_path": "/Users/i/.nvm/versions/node/v0.12.7/bin/node",
    "appbuilder_osx_path": "/Users/i/.nvm/versions/node/v0.12.7/bin/appbuilder"
}
```