### PR TITLE
Fix build and deploy when multiple devices

### DIFF
--- a/app_builder/devices_space.py
+++ b/app_builder/devices_space.py
@@ -27,9 +27,9 @@ def _show_devices_list_and_select_device(app_builder_command, devices, on_device
     elif devicesCount == 1:
         on_device_selected(devices[0])
     elif devicesCount > 1:
-        devicesList = list(map((lambda device: [device["name"],
-                "Platform: {platform} {version}".format(platform=device["platform"], version=device["version"]),
-                "Model: {model}".format(model=device["model"]),
-                "Vendor: {vendor}".format(vendor=device["vendor"])]),
+        devicesList = list(map((lambda device: [device["displayName"] if device.get("displayName") else device["identifier"],
+                "Platform: {platform} {version}".format(platform=device["platform"] if device.get("platform") else "", version=device["version"] if device.get("version") else ""),
+                "Model: {model}".format(model=device["model"] if device.get("model") else ""),
+                "Vendor: {vendor}".format(vendor=device["vendor"] if device.get("vendor") else "")]),
             devices))
         show_quick_panel(app_builder_command.get_window(), devicesList, lambda device_index: on_device_selected(devices[device_index]) if device_index >= 0 else on_device_selected(None))


### PR DESCRIPTION
Fux Build and Deploy option when more than one devices are detected.
The code was trying to access 'name' property which is no longer provided by
`appbuilder device --json` command.
Also this code is failing when any of the properties is missing, for example
Genymotion does not have `model`.

Replace `name` with correct `displayName` and use `identifier` property as backup.
Use empty strings for backup of each property, so the code will work, no matter if it exists for the device.

Fixes http://teampulse.telerik.com/view#item/302971 